### PR TITLE
Remember to clone with submodules

### DIFF
--- a/.github/workflows/gettext.yml
+++ b/.github/workflows/gettext.yml
@@ -15,7 +15,8 @@ jobs:
       uses: actions/checkout@v4
       with:
         token: ${{ secrets.GIT_USER_TOKEN }}
-
+      with:
+        submodules: true
     - name: Update Translation Files
       uses: elementary/actions/gettext-template@main
       env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ jobs:
     if: github.event.pull_request.merged == true && true == contains(join(github.event.pull_request.labels.*.name), 'Release')
     steps:
     - uses: actions/checkout@v4
+      with:
+        submodules: true
     - uses: elementary/actions/release@main
       env:
         GIT_USER_TOKEN: "${{ secrets.GIT_USER_TOKEN }}"


### PR DESCRIPTION
ninja cannot find missing files that are cloned with submodules. This is fixing failing build while running gettext action (and probably release action).