### PR TITLE
Bring back com.github.stsdc.monitor in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Add the PPA of Monitor and then install it:
 
 ```bash
 sudo add-apt-repository ppa:stsdc/monitor
-sudo apt install io.elementary.monitor
+sudo apt install com.github.stsdc.monitor
 ```
 
 Monitor will be available from the Applications menu.


### PR DESCRIPTION
To avoid confusion, this change should stay until it is possible to install Monitor via official PPA.