### PR TITLE
Wayland support for GPU

### DIFF
--- a/src/Resources/GPU/GPUAmd.vala
+++ b/src/Resources/GPU/GPUAmd.vala
@@ -1,6 +1,8 @@
 public class Monitor.GPUAmd : IGPU, Object {
     public SessionManager ? session_manager { get; protected set; }
 
+    public SwitcherooControl? switcheroo_control { get; set; }
+
     public Gee.HashMap<string, HwmonTemperature> hwmon_temperatures { get; set; }
 
     public string hwmon_module_name { get; set; }

--- a/src/Resources/GPU/GPUNvidia.vala
+++ b/src/Resources/GPU/GPUNvidia.vala
@@ -1,6 +1,8 @@
 public class Monitor.GPUNvidia : IGPU, Object {
     public SessionManager ? session_manager { get; protected set; }
 
+    public SwitcherooControl? switcheroo_control { get; set; }
+
     public Gee.HashMap<string, HwmonTemperature> hwmon_temperatures { get; set; }
 
     public string hwmon_module_name { get; set; }

--- a/src/Resources/GPU/IGPU.vala
+++ b/src/Resources/GPU/IGPU.vala
@@ -1,13 +1,16 @@
 public interface Monitor.IGPU : Object {
     public abstract SessionManager ? session_manager { get; public set; }
 
+    public abstract SwitcherooControl ? switcheroo_control { get; public set; }
+
     public abstract Gee.HashMap<string, HwmonTemperature> hwmon_temperatures { get; set; }
 
     public abstract string hwmon_module_name { get; protected set; }
 
     public string name {
         owned get {
-            return session_manager.renderer.split ("(", 2)[0];
+            return (session_manager != null ? session_manager.renderer : switcheroo_control.default_gpu_name)
+                .split ("(", 2)[0];
         }
     }
 


### PR DESCRIPTION
Hey! :D

Since I changed to elementaryOS 8.0 with Wayland, I couldn't see the GPU anymore. I had seen an issue (#355) where @stsdc talked about the GPU stats not beeing supported in Wayland yet, so I tried to add it back to the list of hardware components.

This is probably not the best way to do it, so if you have recommendations on how to improve the code, I'd be happy to make the required changes :)

Here's a screenshot, for reference:
![Captures d'écran de 2025-03-15 15 53 46](https://github.com/user-attachments/assets/b82eb60c-e879-43e5-94aa-d46ef9b24f5e)


### About the implementation
A great part of the code I wrote is heavily inspired from the code used to display the GPU(s) name in elementaryOS system settings ([from here](https://github.com/elementary/switchboard-plug-about/blob/main/src/Views/HardwareView.vala)).

Also, I changed my GPU when upgrading from elmentaryOS 7.1 to 8.0, so I'm not too sure the name displayed in the UI is correct. That is something to take into account as well.