### PR TITLE
Removes stylesheet submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "subprojects/stylesheet"]
-	path = subprojects/stylesheet
-	url = https://github.com/elementary/stylesheet.git

--- a/data/stylesheet/_index.scss
+++ b/data/stylesheet/_index.scss
@@ -1,5 +1,7 @@
-@import "../../subprojects/stylesheet/src/gtk-3.0/palette";
-@import "../../subprojects/stylesheet/src/gtk-3.0/index";
+@import "_palette";
+
+// Text, images, and other foreground elements
+$fg-color: $BLACK_500;
 
 $text_color: $fg_color;
 

--- a/data/stylesheet/_palette.scss
+++ b/data/stylesheet/_palette.scss
@@ -1,0 +1,147 @@
+//@TODO: Could be removed, if Granite will provide palette
+
+// Internal Palette
+$STRAWBERRY_100: #ff8c82;
+$STRAWBERRY_300: #ed5353;
+$STRAWBERRY_500: #c6262e;
+$STRAWBERRY_700: #a10705;
+$STRAWBERRY_900: #7a0000;
+
+$ORANGE_100: #ffc27d;
+$ORANGE_300: #ffa154;
+$ORANGE_500: #f37329;
+$ORANGE_700: #cc3b02;
+$ORANGE_900: #a62100;
+
+$BANANA_100: #fff394;
+$BANANA_300: #ffe16b;
+$BANANA_500: #f9c440;
+$BANANA_700: #d48e15;
+$BANANA_900: #ad5f00;
+
+$LIME_100: #d1ff82;
+$LIME_300: #9bdb4d;
+$LIME_500: #68b723;
+$LIME_700: #3a9104;
+$LIME_900: #206b00;
+
+$MINT_100: #89ffdd;
+$MINT_300: #43d6b5;
+$MINT_500: #28bca3;
+$MINT_700: #0e9a83;
+$MINT_900: #007367;
+
+$BLUEBERRY_100: #8cd5ff;
+$BLUEBERRY_300: #64baff;
+$BLUEBERRY_500: #3689e6;
+$BLUEBERRY_700: #0d52bf;
+$BLUEBERRY_900: #002e99;
+
+$BUBBLEGUM_100: #fe9ab8;
+$BUBBLEGUM_300: #f4679d;
+$BUBBLEGUM_500: #de3e80;
+$BUBBLEGUM_700: #bc245d;
+$BUBBLEGUM_900: #910e38;
+
+$GRAPE_100: #e4c6fa;
+$GRAPE_300: #cd9ef7;
+$GRAPE_500: #a56de2;
+$GRAPE_700: #7239b3;
+$GRAPE_900: #452981;
+
+$COCOA_100: #a3907c;
+$COCOA_300: #8a715e;
+$COCOA_500: #715344;
+$COCOA_700: #57392d;
+$COCOA_900: #3d211b;
+
+$SILVER_100: #fafafa;
+$SILVER_300: #d4d4d4;
+$SILVER_500: #abacae;
+$SILVER_700: #7e8087;
+$SILVER_900: #555761;
+
+$SLATE_100: #95a3ab;
+$SLATE_300: #667885;
+$SLATE_500: #485a6c;
+$SLATE_700: #273445;
+$SLATE_900: #0e141f;
+
+$BLACK_100: #666;
+$BLACK_300: #4d4d4d;
+$BLACK_500: #333;
+$BLACK_700: #1a1a1a;
+$BLACK_900: #000;
+
+// Exported
+@define-color STRAWBERRY_100 #{$STRAWBERRY_100};
+@define-color STRAWBERRY_300 #{$STRAWBERRY_300};
+@define-color STRAWBERRY_500 #{$STRAWBERRY_500};
+@define-color STRAWBERRY_700 #{$STRAWBERRY_700};
+@define-color STRAWBERRY_900 #{$STRAWBERRY_900};
+
+@define-color ORANGE_100 #{$ORANGE_100};
+@define-color ORANGE_300 #{$ORANGE_300};
+@define-color ORANGE_500 #{$ORANGE_500};
+@define-color ORANGE_700 #{$ORANGE_700};
+@define-color ORANGE_900 #{$ORANGE_900};
+
+@define-color BANANA_100 #{$BANANA_100};
+@define-color BANANA_300 #{$BANANA_300};
+@define-color BANANA_500 #{$BANANA_500};
+@define-color BANANA_700 #{$BANANA_700};
+@define-color BANANA_900 #{$BANANA_900};
+
+@define-color LIME_100 #{$LIME_100};
+@define-color LIME_300 #{$LIME_300};
+@define-color LIME_500 #{$LIME_500};
+@define-color LIME_700 #{$LIME_700};
+@define-color LIME_900 #{$LIME_900};
+
+@define-color MINT_100 #{$MINT_100};
+@define-color MINT_300 #{$MINT_300};
+@define-color MINT_500 #{$MINT_500};
+@define-color MINT_700 #{$MINT_700};
+@define-color MINT_900 #{$MINT_900};
+
+@define-color BLUEBERRY_100 #{$BLUEBERRY_100};
+@define-color BLUEBERRY_300 #{$BLUEBERRY_300};
+@define-color BLUEBERRY_500 #{$BLUEBERRY_500};
+@define-color BLUEBERRY_700 #{$BLUEBERRY_700};
+@define-color BLUEBERRY_900 #{$BLUEBERRY_900};
+
+@define-color BUBBLEGUM_100 #{$BUBBLEGUM_100};
+@define-color BUBBLEGUM_300 #{$BUBBLEGUM_300};
+@define-color BUBBLEGUM_500 #{$BUBBLEGUM_500};
+@define-color BUBBLEGUM_700 #{$BUBBLEGUM_700};
+@define-color BUBBLEGUM_900 #{$BUBBLEGUM_900};
+
+@define-color GRAPE_100 #{$GRAPE_100};
+@define-color GRAPE_300 #{$GRAPE_300};
+@define-color GRAPE_500 #{$GRAPE_500};
+@define-color GRAPE_700 #{$GRAPE_700};
+@define-color GRAPE_900 #{$GRAPE_900};
+
+@define-color COCOA_100 #{$COCOA_100};
+@define-color COCOA_300 #{$COCOA_300};
+@define-color COCOA_500 #{$COCOA_500};
+@define-color COCOA_700 #{$COCOA_700};
+@define-color COCOA_900 #{$COCOA_900};
+
+@define-color SILVER_100 #{$SILVER_100};
+@define-color SILVER_300 #{$SILVER_300};
+@define-color SILVER_500 #{$SILVER_500};
+@define-color SILVER_700 #{$SILVER_700};
+@define-color SILVER_900 #{$SILVER_900};
+
+@define-color SLATE_100 #{$SLATE_100};
+@define-color SLATE_300 #{$SLATE_300};
+@define-color SLATE_500 #{$SLATE_500};
+@define-color SLATE_700 #{$SLATE_700};
+@define-color SLATE_900 #{$SLATE_900};
+
+@define-color BLACK_100 #{$BLACK_100};
+@define-color BLACK_300 #{$BLACK_300};
+@define-color BLACK_500 #{$BLACK_500};
+@define-color BLACK_700 #{$BLACK_700};
+@define-color BLACK_900 #{"" + $BLACK_900};


### PR DESCRIPTION
Turns out I was importing whole stylesheet just for `$fg-color: $BLACK_500;` and palette :face_in_clouds: 

Basically hardcodes the palette and one scss variable. This is acceptable until GTK4.