### PR TITLE
Resources: add paths for symbolic icons

### DIFF
--- a/data/icons/icons.indicator.gresource.xml
+++ b/data/icons/icons.indicator.gresource.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <gresources>
   <gresource prefix="/io/elementary/monitor/icons">
-    <file compressed="true" preprocess="xml-stripblanks">cpu-symbolic.svg</file>
-    <file compressed="true" preprocess="xml-stripblanks">gpu-symbolic.svg</file>
-    <file compressed="true" preprocess="xml-stripblanks">ram-symbolic.svg</file>
-    <file compressed="true" preprocess="xml-stripblanks">gpu-vram-symbolic.svg</file>
-    <file compressed="true" preprocess="xml-stripblanks">swap-symbolic.svg</file>
-    <file compressed="true" preprocess="xml-stripblanks">file-deleted-symbolic.svg</file>
-    <file compressed="true" preprocess="xml-stripblanks">temperature-sensor-symbolic.svg</file>
-    <file compressed="true" preprocess="xml-stripblanks">temperature-gpu-symbolic.svg</file>
+    <file compressed="true" preprocess="xml-stripblanks" alias="scalable/devices/cpu-symbolic.svg">cpu-symbolic.svg</file>
+    <file compressed="true" preprocess="xml-stripblanks" alias="scalable/devices/gpu-symbolic.svg">gpu-symbolic.svg</file>
+    <file compressed="true" preprocess="xml-stripblanks" alias="scalable/devices/ram-symbolic.svg">ram-symbolic.svg</file>
+    <file compressed="true" preprocess="xml-stripblanks" alias="scalable/devices/gpu-vram-symbolic.svg">gpu-vram-symbolic.svg</file>
+    <file compressed="true" preprocess="xml-stripblanks" alias="scalable/devices/swap-symbolic.svg">swap-symbolic.svg</file>
+    <file compressed="true" preprocess="xml-stripblanks" alias="scalable/mimetypes/file-deleted-symbolic.svg">file-deleted-symbolic.svg</file>
+    <file compressed="true" preprocess="xml-stripblanks" alias="scalable/devices/temperature-sensor-symbolic.svg">temperature-sensor-symbolic.svg</file>
+    <file compressed="true" preprocess="xml-stripblanks" alias="scalable/devices/temperature-gpu-symbolic.svg">temperature-gpu-symbolic.svg</file>
     <file compressed="true" preprocess="xml-stripblanks" alias="16x16/actions/bash.svg">extra/16/bash.svg</file>
     <file compressed="true" preprocess="xml-stripblanks" alias="48x48/actions/bash.svg">extra/48/bash.svg</file>
     <file compressed="true" preprocess="xml-stripblanks" alias="64x64/actions/bash.svg">extra/64/bash.svg</file>


### PR DESCRIPTION
Symbolic icons need a path in GTK4