### PR TITLE
Update repository URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@
 
 <h4 align="left">Manage processes and monitor system resources</h4>
 
-[![](https://img.shields.io/github/release/stsdc/monitor.svg)]()
-[![Github Workflow Status](https://github.com/stsdc/monitor/actions/workflows/ci.yml/badge.svg)]()
+[![](https://img.shields.io/github/release/elementary/monitor.svg)]()
+[![Github Workflow Status](https://github.com/elementary/monitor/actions/workflows/ci.yml/badge.svg)]()
 [![Translation status](https://l10n.elementary.io/widget/desktop/monitor/svg-badge.svg)](https://l10n.elementary.io/engage/desktop/)
 
-![Monitor Screenshot](https://github.com/stsdc/monitor/raw/main/data/screenshots/monitor-processes.png)
-![Monitor Screenshot](https://github.com/stsdc/monitor/raw/main/data/screenshots/monitor-system.png)
+![Monitor Screenshot](https://github.com/elementary/monitor/raw/main/data/screenshots/monitor-processes.png)
+![Monitor Screenshot](https://github.com/elementary/monitor/raw/main/data/screenshots/monitor-system.png)
 
 ## Install
 
@@ -52,7 +52,7 @@ sudo apt install build-essential cmake sassc valac libgtk-3-dev libgee-0.8-dev l
 
 1. Clone:
    ```bash
-   git clone https://github.com/stsdc/monitor
+   git clone https://github.com/elementary/monitor
    cd monitor
    ```
 

--- a/data/io.elementary.monitor.appdata.xml.in
+++ b/data/io.elementary.monitor.appdata.xml.in
@@ -16,16 +16,16 @@
   </custom>
     <screenshots>
     <screenshot type="default">
-      <image>https://github.com/stsdc/monitor/raw/0.17.2/data/screenshots/monitor-processes.png</image>
+      <image>https://github.com/elementary/monitor/raw/0.17.2/data/screenshots/monitor-processes.png</image>
     </screenshot>
     <screenshot>
-      <image>https://github.com/stsdc/monitor/0.17.2/master/data/screenshots/monitor-system.png</image>
+      <image>https://github.com/elementary/monitor/0.17.2/master/data/screenshots/monitor-system.png</image>
     </screenshot>
   </screenshots>
   <developer_name>Stanisław Dac</developer_name>
-  <url type="homepage">https://github.com/stsdc/monitor</url>
-  <url type="bugtracker">https://github.com/stsdc/monitor/issues</url>
-<url type="help">https://github.com/stsdc/monitor/issues</url>
+  <url type="homepage">https://github.com/elementary/monitor</url>
+  <url type="bugtracker">https://github.com/elementary/monitor/issues</url>
+<url type="help">https://github.com/elementary/monitor/issues</url>
 
 <releases>
 <release version="0.11.0" date="2021-10-24">

--- a/data/io.elementary.monitor.appdata.xml.in
+++ b/data/io.elementary.monitor.appdata.xml.in
@@ -25,7 +25,7 @@
   <developer_name>Stanisław Dac</developer_name>
   <url type="homepage">https://github.com/elementary/monitor</url>
   <url type="bugtracker">https://github.com/elementary/monitor/issues</url>
-<url type="help">https://github.com/elementary/monitor/issues</url>
+  <url type="help">https://github.com/elementary/monitor/issues</url>
 
 <releases>
 <release version="0.11.0" date="2021-10-24">

--- a/data/io.elementary.monitor.appdata.xml.in
+++ b/data/io.elementary.monitor.appdata.xml.in
@@ -19,7 +19,7 @@
       <image>https://github.com/elementary/monitor/raw/0.17.2/data/screenshots/monitor-processes.png</image>
     </screenshot>
     <screenshot>
-      <image>https://github.com/elementary/monitor/0.17.2/master/data/screenshots/monitor-system.png</image>
+      <image>https://github.com/elementary/monitor/0.17.2/main/data/screenshots/monitor-system.png</image>
     </screenshot>
   </screenshots>
   <developer_name>Stanisław Dac</developer_name>

--- a/data/io.elementary.monitor.appdata.xml.in
+++ b/data/io.elementary.monitor.appdata.xml.in
@@ -19,7 +19,7 @@
       <image>https://github.com/elementary/monitor/raw/0.17.2/data/screenshots/monitor-processes.png</image>
     </screenshot>
     <screenshot>
-      <image>https://github.com/elementary/monitor/0.17.2/main/data/screenshots/monitor-system.png</image>
+      <image>https://github.com/elementary/monitor/raw/0.17.2/data/screenshots/monitor-system.png</image>
     </screenshot>
   </screenshots>
   <developer_name>Stanisław Dac</developer_name>

--- a/src/Widgets/Statusbar/Statusbar.vala
+++ b/src/Widgets/Statusbar/Statusbar.vala
@@ -54,7 +54,7 @@ public class Monitor.Statusbar : Gtk.ActionBar {
         pack_start (gpu_usage_label);
 
         var support_ua_label = new Gtk.LinkButton.with_label ("http://stand-with-ukraine.pp.ua/", _("🇺🇦"));
-        var github_label = new Gtk.LinkButton.with_label ("https://github.com/stsdc/monitor", _("Check on Github"));
+        var github_label = new Gtk.LinkButton.with_label ("https://github.com/elementary/monitor", _("Check on Github"));
 
         var version_label = new Gtk.Label ("%s".printf (VCS_TAG)) {
             selectable = true


### PR DESCRIPTION
Update to the URL after migration to the elementary Organization. Also fix a wrong URL in the metainfo screenshot while we're here.
