### PR TITLE
Metainfo: Fix deprecated developer_name

### DIFF
--- a/data/io.elementary.monitor.appdata.xml.in
+++ b/data/io.elementary.monitor.appdata.xml.in
@@ -22,7 +22,11 @@
       <image>https://github.com/elementary/monitor/raw/0.17.2/data/screenshots/monitor-system.png</image>
     </screenshot>
   </screenshots>
-  <developer_name>Stanisław Dac</developer_name>
+  <developer id="org.elementaryos">
+    <name>elementary, Inc.</name>
+  </developer>
+  <project_group>elementary</project_group>
+  <update_contact>contact_at_elementary.io</update_contact>
   <url type="homepage">https://github.com/elementary/monitor</url>
   <url type="bugtracker">https://github.com/elementary/monitor/issues</url>
   <url type="help">https://github.com/elementary/monitor/issues</url>


### PR DESCRIPTION
The `developer_name` tag has been [deprecated](https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-developer_name) since AppStream 1.0.0, so replaced with the `developer` tag. I used elementary instead of @stsdc in the `id` and `name` since Monitor is now under elementary Organization.

Also add `project_group` and `update_contact` as we do anywhere while I'm here.
