### PR TITLE
Styles: remove dim-label override

### DIFF
--- a/data/stylesheet/_index.scss
+++ b/data/stylesheet/_index.scss
@@ -172,10 +172,6 @@ $text_color: $fg_color;
     }
 }
 
-.dim-label {
-    color: rgba($text_color, 0.5);
-}
-
 .small-text {
     font-weight:bold;
     font-size:9px;


### PR DESCRIPTION
Shouldn't mess with default styles like this. This messes up contrast in some places