### PR TITLE
ProcessView: reduce object access, build ui in construct

### DIFF
--- a/src/Views/ProcessView/ProcessView.vala
+++ b/src/Views/ProcessView/ProcessView.vala
@@ -4,34 +4,32 @@
  */
 
 public class Monitor.ProcessView : Gtk.Box {
-    public TreeViewModel treeview_model;
-    public CPUProcessTreeView process_tree_view;
+    public TreeViewModel treeview_model { get; private set; }
+    public CPUProcessTreeView process_tree_view { get; private set; }
 
-    public ProcessInfoView process_info_view;
+    private ProcessInfoView process_info_view;
 
     construct {
-        process_info_view = new ProcessInfoView ();
-
-        // hide on startup
-        process_info_view.no_show_all = true;
-    }
-
-    public ProcessView () {
         treeview_model = new TreeViewModel ();
 
         process_tree_view = new CPUProcessTreeView (treeview_model);
         process_tree_view.process_selected.connect ((process) => on_process_selected (process));
 
-        // making tree view scrollable
-        var process_tree_view_scrolled = new Gtk.ScrolledWindow (null, null);
-        process_tree_view_scrolled.add (process_tree_view);
+        var process_tree_view_scrolled = new Gtk.ScrolledWindow (null, null) {
+            child = process_tree_view
+        };
 
-        var paned = new Gtk.Paned (Gtk.Orientation.HORIZONTAL);
+        process_info_view = new ProcessInfoView () {
+            // hide on startup
+            no_show_all = true
+        };
+
+        var paned = new Gtk.Paned (HORIZONTAL) {
+            hexpand = true
+        };
+        paned.position = paned.max_position;
         paned.pack1 (process_tree_view_scrolled, true, false);
         paned.pack2 (process_info_view, false, false);
-        // paned.set_min_position (200);
-        paned.set_position (paned.max_position);
-        paned.set_hexpand (true);
 
         add (paned);
     }
@@ -39,7 +37,6 @@ public class Monitor.ProcessView : Gtk.Box {
     public void on_process_selected (Process process) {
         process_info_view.process = process;
         process_info_view.no_show_all = false;
-        //  process_info_view.show_all ();
     }
 
     public void update () {
@@ -54,5 +51,4 @@ public class Monitor.ProcessView : Gtk.Box {
         });
 
     }
-
 }


### PR DESCRIPTION
* If things have to be publicly gettable, make sure they're private set
* `process_info_view` doesn't seem to need to be public
* use `construct` block since nothing is a construction argument
* initialize properties with objects