### PR TITLE
Chart: hide overflow

### DIFF
--- a/src/Widgets/Chart/Chart.vala
+++ b/src/Widgets/Chart/Chart.vala
@@ -15,6 +15,7 @@ public class Monitor.Chart : Gtk.Box {
 
         vexpand = true;
         height_request = 120;
+        overflow = HIDDEN;
 
         config = new LiveChart.Config ();
         config.y_axis.unit = "%";


### PR DESCRIPTION
It's not super obvious but charts currently go outside the corners of their rounded containers

<img width="60" height="44" alt="Screenshot from 2025-10-03 12 59 40" src="https://github.com/user-attachments/assets/387c45d4-cee6-49f0-9237-04c9c5e26dfa" />
