### PR TITLE
Swap positions of network indicators and preferences checkboxes

### DIFF
--- a/src/Indicator/Widgets/DisplayWidget.vala
+++ b/src/Indicator/Widgets/DisplayWidget.vala
@@ -89,7 +89,7 @@ public class Monitor.Widgets.DisplayWidget : Gtk.Box {
         append (gpu_widget);
         append (gpu_memory_widget);
         append (gpu_temperature_widget);
-        append (network_up_widget);
         append (network_down_widget);
+        append (network_up_widget);
     }
 }

--- a/src/Views/PreferencesView.vala
+++ b/src/Views/PreferencesView.vala
@@ -122,8 +122,8 @@ public class Monitor.PreferencesView : Granite.Bin {
         indicator_options_box.append (gpu_memory_check);
         indicator_options_box.append (gpu_temp_check);
         indicator_options_box.append (new Gtk.Separator (HORIZONTAL));
-        indicator_options_box.append (network_upload_check);
         indicator_options_box.append (network_download_check);
+        indicator_options_box.append (network_upload_check);
 
         var indicator_options_revealer = new Gtk.Revealer () {
             child = indicator_options_box


### PR DESCRIPTION
Move network download indicator/checkbox to the left of upload.